### PR TITLE
Add valid_move? to Knight class and tested working in rspec

### DIFF
--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -1,5 +1,16 @@
 class Knight < Piece
   def valid_move?(x_new, y_new)
-    true
+    return false if move_type(x_new, y_new) == :invalid
+    return false if !(game.piece_present(x_new, y_new).nil?) && game.piece_present(x_new, y_new).color == self.color
+    # pulls the absolute value of the distance of the 
+    # new space from the user's selected space
+    x_diff = x_diff(x_new).abs
+    y_diff = y_diff(y_new).abs
+
+    if x_diff == 1 && y_diff == 2 || y_diff == 1 && x_diff == 2
+      return true
+    else 
+      false
+    end
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -22,13 +22,17 @@ class Piece < ApplicationRecord
 
   def move_type(x_new, y_new)
     # Need to deal with Knight case
-    horizontal_delta = (x_new - x_pos).abs
-    vertical_delta = (y_new - y_pos).abs
+    vertical_delta = (x_new - x_pos).abs
+    horizontal_delta = (y_new - y_pos).abs
 
     return :horizontal if horizontal_delta > 0 && vertical_delta.zero?
     return :vertical if vertical_delta > 0 && horizontal_delta.zero?
     return :diagonal if vertical_delta == horizontal_delta
-    return :invalid if vertical_delta > 0 && horizontal_delta > 0 && vertical_delta != horizontal_delta && type != "Knight"
+    # Knight case is a bit of a hack, tried the code below, could not quite get it to pass the test. This needs to be addressed 
+    # at some point
+    # return :knight if Rational(vertical_delta, horizontal_delta) == (2/1) || Rational(vertical_delta, horizontal_delta) == (1/2)
+    return :knight if self.type = "Knight"
+    return :invalid if vertical_delta > 0 && horizontal_delta > 0 && vertical_delta != horizontal_delta
   end
 
   def is_obstructed?(x_new, y_new)
@@ -70,5 +74,9 @@ class Piece < ApplicationRecord
       occupant.update_attributes(x_pos: nil, y_pos: nil)
     else return raise "Invalid move"
     end
+  end
+
+  def piece_color
+    self.color
   end
 end

--- a/spec/models/knight_spec.rb
+++ b/spec/models/knight_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Knight, type: :model do
+  it 'is created with populate_game method' do
+    game = FactoryBot.create(:game)
+    user = FactoryBot.create(:user)
+    game.black_player_user_id = user.id
+    game.populate_game!
+    expect(game.pieces.where(type: "Knight").size).to be(2)
+  end
+
+  it 'has a valid_move? method that returns true for a 2-to-1 move in any direction' do
+    game = FactoryBot.create(:game)
+    user = FactoryBot.create(:user)
+    game.black_player_user_id = user.id
+    game.populate_game!
+    knight = game.pieces.where("x_pos = ? AND y_pos = ?", 7, 1).first
+    expect(knight.valid_move?(5, 2)).to eq(true)
+    expect(knight.valid_move?(5, 0)).to eq(true)
+    expect(knight.valid_move?(6, 3)).to eq(false)
+    expect(knight.valid_move?(6, 4)).to eq(false)
+    expect(knight.valid_move?(5, 3)).to eq(false)
+  end
+  
+  it 'should be able to move 2-1 to around the board using move_to!' do
+    Game.destroy_all
+    User.destroy_all
+    Piece.destroy_all
+    game = FactoryBot.create(:game)
+    user = FactoryBot.create(:user)
+    game.black_player_user_id = user.id
+    game.populate_game!
+    Knight.first.move_to!(5, 2)
+    Knight.first.move_to!(4, 4)
+    expect(game.pieces.where("x_pos = ? AND y_pos = ?", 4, 4).first.id).to eq(Knight.first.id)
+  end
+end


### PR DESCRIPTION
- Added logic to deal with the Knight 2-to-1 move cases
- Left out a call to is_obstructed?
- Added a rudimentary "Knight" move_type to Piece.move_type method

Need to deal with the Knight move type in a more elegant way than just ignoring it. My idea was to use Rationals to do it, but my test was failing on a 1/2 and I ran out of time to keep playing with it.