### PR TITLE
Add back migration for row and column rename

### DIFF
--- a/db/migrate/20181120015518_change_piece_row_column_names.rb
+++ b/db/migrate/20181120015518_change_piece_row_column_names.rb
@@ -1,0 +1,6 @@
+class ChangePieceRowColumnNames < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :pieces, :current_row, :x_pos
+    rename_column :pieces, :current_column, :y_pos
+  end
+end


### PR DESCRIPTION
Fixes missing migration for @kwurohe to be able to push through heroku migration