### PR TITLE
Tested Pawn moves in UI and fixed issues with is_obstructed?

### DIFF
--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,6 +1,7 @@
 class Pawn < Piece
   def valid_move?(x_new, y_new)
     return true if capture_move?(x_new, y_new)
+    return false if is_obstructed?(x_new, y_new)
     return false if !within_bounds?(x_new, y_new)
     return false if backwards_move?(x_new)
     return false if vertical_blocker?(x_new, y_new)

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,11 +1,11 @@
 class Pawn < Piece
   def valid_move?(x_new, y_new)
+    return true if capture_move?(x_new, y_new)
     return false if !within_bounds?(x_new, y_new)
     return false if backwards_move?(x_new)
-    # once capture move logic is complete, will add return true if capture_move(x_new, y_new)
-    return false if horizontal_move?(y_new)
-    # return false if is_obstructed?(x_new, y_new)
-    okay_length?(x_new)
+    return false if vertical_blocker?(x_new, y_new)
+    return false if horizontal_move?(x_new)
+    okay_length?(y_new)
   end
   
   def backwards_move?(x_new)
@@ -17,7 +17,12 @@ class Pawn < Piece
   
   # still need to add capture move logic
 
-  def capture_move(x_new, y_new)
+  def capture_move?(x_new, y_new)
+    target = game.pieces.where("x_pos = ? AND y_pos = ?", x_new, y_new).first
+    return false if target.nil?
+    if move_type(x_new, y_new) == :diagonal && x_diff(x_new) == 1 && y_diff(y_new) == 1
+      target.color != self.color && target.type != "King"
+    end
   end
   
   def first_move?(y_new)
@@ -26,16 +31,21 @@ class Pawn < Piece
     (color && y_pos == 1) || (!color && y_pos == 6)
   end
   
-  def okay_length?(x_new)
-    x_diff = x_diff(x_new)
+  def okay_length?(y_new)
+    y_diff = y_diff(y_new)
     # if it's first move, distance can be 1 or 2; else distance is 1
-    first_move?(x_new) ? (x_diff == 1 || x_diff == 2) : x_diff == 1
+    first_move?(y_new) ? (y_diff == 1 || y_diff == 2) : y_diff == 1
   end
     
-  def horizontal_move?(y_new)
+  def horizontal_move?(x_new)
     # check if x-position is changing
-    y_diff = y_diff(y_new)
-    y_diff != 0
+    x_diff = x_diff(x_new)
+    x_diff != 0
+  end
+
+  def vertical_blocker?(x_new, y_new)
+    blocker = game.pieces.where("x_pos = ? AND y_pos = ?", x_new, y_new).first
+    !blocker.nil?
   end
 
   def symbol

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -44,32 +44,29 @@ class Piece < ApplicationRecord
 
   def is_obstructed?(x_new, y_new)
     puts "IS OBSTRUCTED??"
-    move_direction = move_type(x_new, y_new)
     pieces_in_row = game.pieces.where(x_pos: x_new)
     pieces_in_column = game.pieces.where(y_pos: y_new)
     # horizontal case
-    if move_direction == :horizontal
+    if move_type(x_new, y_new) == :horizontal
       puts "HELLO THERE, WE ARE IN THE HORIZONTAL MOVE DIRECTION"
-      return false if pieces_in_row.where("#{x_new} > ? AND #{x_new} < ?", [x_pos, x_new].min, [x_pos, x_new].max).empty?
+      !pieces_in_column.where("x_pos > ? AND x_pos < ?", [self.x_pos, x_new].min, [self.x_pos, x_new].max).empty?
       puts "HELLO THERE, WE ARE IN THE HORIZONTAL MOVE DIRECTION PART 2"
     # vertical case
-    elsif move_direction == :vertical
-      return false if pieces_in_column.where("#{y_new} > ? AND #{y_new} < ?", [y_pos, y_new].min, [y_pos, y_new].max).empty?
+    elsif move_type(x_new, y_new) == :vertical
+      !pieces_in_row.where("y_pos > ? AND y_pos < ?", [self.y_pos, y_new].min, [self.y_pos, y_new].max).empty?
     # diagonal case
-    elsif move_direction == :diagonal
+    elsif move_type(x_new, y_new) == :diagonal
       (x_pos..x_new).each do |x|
-        next if x == x_pos
+        next if x == self.x_pos
         return false if x == x_new
         (y_pos..y_new).each do |y|
-          next if y == y_pos
-          ## why 2 instead of 1?
-          # should be 1 (BK)
-          return true if game.pieces.where(x_pos: x, y_pos: y).size == 1
+          next if y == self.y_pos
+          game.pieces.where(x_pos: x, y_pos: y).size == 1
         end
       end
+      puts "HELLO WE ARE IN THE NEXT STEP OF OBSTRUCTED"
+      raise "Invalid move" if move_type(x_new, y_new) == :invalid
     end
-    puts "HELLO WE ARE IN THE NEXT STEP OF OBSTRUCTED"
-    raise "Invalid move" if move_direction == :invalid
   end
 
   # move_to! method calls valid_move? and will update a piece instance's

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -56,14 +56,8 @@ class Piece < ApplicationRecord
       !pieces_in_row.where("y_pos > ? AND y_pos < ?", [self.y_pos, y_new].min, [self.y_pos, y_new].max).empty?
     # diagonal case
     elsif move_type(x_new, y_new) == :diagonal
-      (x_pos..x_new).each do |x|
-        next if x == self.x_pos
-        return false if x == x_new
-        (y_pos..y_new).each do |y|
-          next if y == self.y_pos
-          game.pieces.where(x_pos: x, y_pos: y).size == 1
-        end
-      end
+      diagonal_blocker?(x_new, y_new)
+    else
       puts "HELLO WE ARE IN THE NEXT STEP OF OBSTRUCTED"
       raise "Invalid move" if move_type(x_new, y_new) == :invalid
     end
@@ -104,5 +98,17 @@ class Piece < ApplicationRecord
 
   def starting_state
     self.state ||= 'unmoved'
+  end
+
+  def diagonal_blocker?(x, y, idx = 0)
+    x_range = (self.x_pos..x).to_a.tap { |x| x.pop; x.shift }
+    y_range = (self.y_pos..y).to_a.tap { |y| y.pop; y.shift }
+    if !game.piece_present(x_range[idx], y_range[idx]) && idx != idx[-1]
+      idx = idx + 1
+      diagonal_blocker?(x, y, idx)
+    elsif !game.piece_present(x_range[idx], y_range[idx]) && idx == idx[-1]
+      false
+    else return true
+    end
   end
 end


### PR DESCRIPTION
is_obstructed? had some issues ... the raise error at the end wasn't inside the conditional, so it would just automatically return whenever it was called. (#23)

I moved the error raise into the conditional, and fixed the cases so they were checking the right squares. Looks good on the board except for the Queen piece, which might be related to some subclass method. If someone else wants to take a look feel free. 

That whole is_obstructed? method should be broken up into smaller methods for each case to make it a little cleaner and more readable, but it appears to be (mostly) functional.