### PR TITLE
Fix double piece creation

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -25,9 +25,6 @@ class GamesController < ApplicationController
     @game = Game.find(params[:id])
     return render_not_found if @game.nil?
     @game.update_attribute(:black_player_user_id, current_user.id)
-    # May need to remove one of these methods - BK
-    @game.populate_game!
-    @game.set_player_ids
     redirect_to game_path(@game.id)
   end
 
@@ -35,9 +32,6 @@ class GamesController < ApplicationController
     @game = Game.find(params[:id])
     return render_not_found if @game.nil?
     @game.update_attribute(:white_player_user_id, current_user.id)
-    # May need to remove one of these methods - BK
-    @game.populate_game!
-    @game.set_player_ids
     redirect_to game_path(@game.id)
   end
 

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -1,5 +1,6 @@
 class PiecesController < ApplicationController
   skip_before_action :verify_authenticity_token
+  before_filter :set_cache_headers
   before_action :set_game!
 
   def index
@@ -94,6 +95,12 @@ class PiecesController < ApplicationController
 
   def piece_params
     params.require(:piece).permit(:game_id, :user_id, :type, :color, :x_pos, :y_pos, :x_new, :y_new)
+  end
+
+  def set_cache_headers
+    response.headers["Cache-Control"] = "no-cache, no-store"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
   end
 end
 

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -1,6 +1,6 @@
 class PiecesController < ApplicationController
   skip_before_action :verify_authenticity_token
-  before_filter :set_cache_headers
+  # before_filter :set_cache_headers
   before_action :set_game!
 
   def index
@@ -97,10 +97,10 @@ class PiecesController < ApplicationController
     params.require(:piece).permit(:game_id, :user_id, :type, :color, :x_pos, :y_pos, :x_new, :y_new)
   end
 
-  def set_cache_headers
-    response.headers["Cache-Control"] = "no-cache, no-store"
-    response.headers["Pragma"] = "no-cache"
-    response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
-  end
+  # def set_cache_headers
+  #   response.headers["Cache-Control"] = "no-cache, no-store"
+  #   response.headers["Pragma"] = "no-cache"
+  #   response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
+  # end
 end
 

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -94,10 +94,11 @@ class King < Piece
  
     if !user_id
       self.game.pieces.each do |piece|
-        return true if piece.valid_move?(x_king, y_king)
+        if piece.valid_move?(x_king, y_king)
+          return true
+        end
       end
-    end
- 
+    end 
     return false
   end
 end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -86,4 +86,18 @@ class King < Piece
     self.update_attributes!(x_pos: x_new)   
   end
 
+  def in_check?
+    # king = pieces.find_by(type: 'King', user_id: current_user.id)
+    king = self
+    x_king = king.x_pos
+    y_king = king.y_pos
+ 
+    if !user_id
+      self.game.pieces.each do |piece|
+        return true if piece.valid_move?(x_king, y_king)
+      end
+    end
+ 
+    return false
+  end
 end

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -41,15 +41,16 @@ RSpec.describe PiecesController, type: :controller do
 
       # Switch to piece controller, send put request to move method
       @controller = PiecesController.new
-      piece = game.pieces.where("x_pos = ? AND y_pos = ?", 6, 4).first
+      piece = game.pieces.where("x_pos = ? AND y_pos = ?", 4, 6).first
+      puts piece
       put :move, params: { 
                             game_id: game.id,
                             id: piece.id,
-                            x_new: 5,
-                            y_new: 4
+                            x_new: 4,
+                            y_new: 5
                           }
       piece.reload
-      expect(piece.x_pos).to eq(5)
+      expect(piece.x_pos).to eq(4)
     end
   end 
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -30,5 +30,4 @@ FactoryBot.define do
 
   factory :rook do
   end
-
 end

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -57,4 +57,20 @@ RSpec.describe King, type: :model do
     end
 
   end
+
+  describe 'king in_check?' do
+    it 'should return true when king is in check' do
+      game = FactoryBot.create(:game)
+      user1 = FactoryBot.create(:user)
+      user2 = FactoryBot.create(:user)
+      game.black_player_user_id = user1.id
+      game.white_player_user_id = user2.id
+
+      king = FactoryBot.create(:king, x_pos: 2, y_pos: 0, color: true, game: game)
+      rook = FactoryBot.create(:rook, x_pos: 4, y_pos: 0, color: false, game: game)
+
+      expect(king.in_check?).to be true
+
+    end
+  end
 end

--- a/spec/models/knight_spec.rb
+++ b/spec/models/knight_spec.rb
@@ -3,10 +3,7 @@ require 'rails_helper'
 RSpec.describe Knight, type: :model do
   it 'is created with populate_game method' do
     game = FactoryBot.create(:game)
-    user = FactoryBot.create(:user)
-    game.black_player_user_id = user.id
-    game.populate_game!
-    expect(game.pieces.where(type: "Knight").size).to be(2)
+    expect(game.pieces.where(type: "Knight").size).to be(4)
   end
 
   it 'has a valid_move? method that returns true for a 2-to-1 move in any direction' do
@@ -14,9 +11,9 @@ RSpec.describe Knight, type: :model do
     user = FactoryBot.create(:user)
     game.black_player_user_id = user.id
     game.populate_game!
-    knight = game.pieces.where("x_pos = ? AND y_pos = ?", 7, 1).first
-    expect(knight.valid_move?(5, 2)).to eq(true)
-    expect(knight.valid_move?(5, 0)).to eq(true)
+    knight = game.pieces.where("x_pos = ? AND y_pos = ?", 1, 7).first
+    expect(knight.valid_move?(2, 5)).to eq(true)
+    expect(knight.valid_move?(0, 5)).to eq(true)
     expect(knight.valid_move?(6, 3)).to eq(false)
     expect(knight.valid_move?(6, 4)).to eq(false)
     expect(knight.valid_move?(5, 3)).to eq(false)


### PR DESCRIPTION
Piece count before = 64, piece count after = 32. This removes redundant calls to populate_game! and set_player_ids from the join_as_color methods on the game controller. Duplicate pieces do not appear on refresh after a move. Fixes issue #25 